### PR TITLE
make distro page more obvious

### DIFF
--- a/source/downloads/index.html
+++ b/source/downloads/index.html
@@ -13,10 +13,28 @@
     <div class="panel panel-default">
       <div class="panel-body trim">
 
+        <h3 class="trim-top">System packages</h3>
+
+
+
         <h3 class="trim-top">Rakudo Star</h3>
+
         <p> Rakudo Star 2018.10 is a useful and usable production distribution of
         Perl 6 which supports the latest Christmas Perl 6 (6.c language
         version).<p>
+
+        <p>Keep in mind that Rakudo Star is realeased very frequently.
+        if you don't mind being potentialy a bit outdated and enjoy the ease of your
+        distro packaging, you can pick one of those.</p>
+
+        <ul>
+          <li><a name="Homebrew">Homebrew</a></li>
+          <li><a name="OpenSUSE">OpenSUSE Rakudo packages</a></li>
+          <li><a name="pkgsrc">pkgsrc (Work in Progress)</a></li>
+          <li><a name="Debian">Debian perl6 packages</a></li>
+          <li><a name="OpenBSD">OpenBSD Rakudo Ports</a></li>
+          <li><a name="Docker">Rakudo Star Docker</a></li>
+        </ul>
 
         <h3 class="trim-top">Installing from binaries</h3>
 
@@ -63,7 +81,18 @@
             ><i class="glyphicon glyphicon-gift"></i>
               Pkgs and Repos for Rakudo Compiler+Zef</a>
         </p>
-        <p><a href="/downloads/others.html">Other 3rd Party Packages</a></p>
+        <p>
+
+          <h4><a name="Chocolately">Chocolately Rakudo Star</a></h4>
+          <h4><a name="Homebrew">Homebrew</a></h4>
+          <h4><a name="OpenSUSE">OpenSUSE Rakudo packages</a></h4>
+          <h4><a name="pkgsrc">pkgsrc (Work in Progress)</a></h4>
+          <h4><a name="Debian">Debian perl6 packages</a></h4>
+          <h4><a name="OpenBSD">OpenBSD Rakudo Ports</a></h4>
+          <h4><a name="Docker">Rakudo Star Docker</a></h4>
+
+        <a href="/downloads/others.html">Other 3rd Party Packages</a>
+        </p>
       </div>
     </div>
   </div>

--- a/source/downloads/others.html
+++ b/source/downloads/others.html
@@ -21,7 +21,7 @@
       <div class="panel-body">
 
           <h3>Windows</h3>
-          <h4>Chocolately Rakudo Star</h4>
+          <h4><a name="Chocolately">Chocolately Rakudo Star</a></h4>
           <ul class="shy-list">
               <li><a href="https://chocolatey.org/packages/rakudostar">https://chocolatey.org/packages/rakudostar</a>
                   <ul>    
@@ -34,7 +34,7 @@
           </ul>
 
           <h3>macOS</h3>
-          <h4>Homebrew</h4>
+          <h4><a name="Homebrew">Homebrew</a></h4>
           <ul class="shy-list">
               <li><a href="https://github.com/Homebrew/homebrew-core/blob/master/Formula/rakudo-star.rb">https://github.com/Homebrew/homebrew-core/blob/master/Formula/rakudo-star.rb</a>
                   <ul>
@@ -43,7 +43,7 @@
           </ul>
 
           <h3>Linux and UNIX-like</h3>
-          <h4>nxadm's Rakudo & zef packages and repositories</h4>
+          <h4><a name="nxadm">nxadm's Rakudo & zef packages and repositories</a></h4>
           <ul class="shy-list">
               <li><a href="https://nxadm.github.io/rakudo-pkg">https://nxadm.github.io/rakudo-pkg</a>
                   <ul>    
@@ -55,7 +55,7 @@
               </li>
           </ul>
 
-          <h4>OpenSUSE Rakudo packages</h4>
+          <h4><a name="OpenSUSE Rakudo packages">OpenSUSE Rakudo packages</a></h4>
           <ul class="shy-list">
               <li><a href="https://build.opensuse.org/project/show/devel:languages:perl6">https://build.opensuse.org/project/show/devel:languages:perl6</a>
                   <ul>    
@@ -66,7 +66,7 @@
               </li>
           </ul>
 
-          <h4>pkgsrc (Work in Progress)</h4>
+          <h4><a name="pkgsrc">pkgsrc (Work in Progress)</a></h4>
           <ul class="shy-list">
               <li><a href="http://pkgsrc.se/wip/rakudo">http://pkgsrc.se/wip/rakudo</a>
                   <ul>
@@ -77,7 +77,7 @@
               </li>
           </ul>
 
-          <h4>Debian perl6 packages</h4>
+          <h4><a name="Debian">Debian perl6 packages</a></h4>
           <ul class="shy-list">
               <li><a href="https://packages.debian.org/search?keywords=perl6">https://packages.debian.org/search?keywords=perl6</a>
                   <ul>
@@ -87,12 +87,12 @@
               </li>
           </ul>
 
-          <h4>OpenBSD Rakudo Ports</h4>
+          <h4><a name="OpenBSD">OpenBSD Rakudo Ports</a></h4>
           <ul class="shy-list">
               <li><a href="http://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/lang/rakudo/">http://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/lang/rakudo/</a></li>
           </ul>
 
-          <h4>Rakudo Star Docker</h4>
+          <h4><a name="Docker">Rakudo Star Docker</a></h4>
           <ul class="shy-list">
               <li><a href="https://hub.docker.com/_/rakudo-star/">https://hub.docker.com/_/rakudo-star/</a></li>
           </ul>         


### PR DESCRIPTION
i got to the distro page through the cro documentation and realized that if i
wasn't aware about the debian package, i wouldn't had find it.

this is an attempt to fix it.

https://cro.services/docs/intro/getstarted points to
https://perl6.org/downloads/ and this page is very confusing at first
because you have this "Installing from binaries" that goes to
"https://rakudo.org/files/" with nothing related to the distro
packaging. You have to be carreful to notice in the menu (so not in the
content you're reading), there is this little text entry under a big icon,
that finally give you a pointer to the holy graal which is
https://perl6.org/downloads/others.html.