### PR TITLE
Refine the code examples section UI of index page

### DIFF
--- a/source/js.js
+++ b/source/js.js
@@ -16,6 +16,7 @@ jQuery(function ($) {
     if ( ! $('.bg').length ) { $('body').css({background: '#fff'}) }
 
     setup_recent_blog_posts();
+    update_pre_tag_left_top_border_radius();
 });
 
 function setup_recent_blog_posts () {
@@ -34,5 +35,21 @@ function setup_recent_blog_posts () {
     })
     .fail(function() {
         el.append('<li><i>Failed to fetch recent blogs</i></li>');
+    });
+}
+
+// This function updates first <pre> tag's left-top border radius
+// responsively when the different tab is clicked
+function update_pre_tag_left_top_border_radius () {
+    $(document).ready(function() {
+        $('.tab-content') > $('pre').first().css('border-radius', '0px 4px 4px');
+        $('ul.nav-tabs li').click(function(e) {
+            var firstPreEl = $('.tab-content') > $('pre').first();
+            if ($(this).index() === 0) {
+                firstPreEl.css('border-radius', '0px 4px 4px');
+            } else {
+                firstPreEl.css('border-radius', '4px');
+            }
+        });
     });
 }

--- a/source/style.css
+++ b/source/style.css
@@ -99,6 +99,10 @@ footer {
 .nav-tabs * {
   outline: 0 !important; }
 
+.nav-tabs {
+  border-bottom: 0px;
+}
+
 .trim-top {
   margin-top: 0; }
 
@@ -118,6 +122,7 @@ footer {
 
 /* https://github.com/stmuk/p6-Text-VimColour  Highlighter */
 .highlight pre {
+  height: 260px;
   white-space: pre-wrap;
   font-family: monospace;
   color: #000;

--- a/source/style.css
+++ b/source/style.css
@@ -100,8 +100,7 @@ footer {
   outline: 0 !important; }
 
 .nav-tabs {
-  border-bottom: 0px;
-}
+  border-bottom: 0px; }
 
 .trim-top {
   margin-top: 0; }
@@ -122,12 +121,12 @@ footer {
 
 /* https://github.com/stmuk/p6-Text-VimColour  Highlighter */
 .highlight pre {
-  height: 260px;
   white-space: pre-wrap;
   font-family: monospace;
   color: #000;
   background-color: #F5F5F5;
-  font-family: monospace; }
+  font-family: monospace;
+  height: 260px; }
 .highlight .Comment {
   color: #777; }
 .highlight .Constant {

--- a/source/style.scss
+++ b/source/style.scss
@@ -150,6 +150,10 @@ footer {
     outline: 0!important;
 }
 
+.nav-tabs {
+    border-bottom: 0px;
+}
+
 .trim-top {
     margin-top: 0;
 }
@@ -183,6 +187,7 @@ footer {
         color: #000;
         background-color: #F5F5F5;
         font-family: monospace;
+        height: 260px;
     }
     .Comment { color: #777; }
     .Constant { color: #0000c0;  }
@@ -222,9 +227,9 @@ footer {
     top: 2px;
 }
 
-#navbar { 
+#navbar {
     padding-left: 16px;
-    
+
     a[href*="//"]:after {
         padding-left: 3px;
         content: url(/external-link-icon.svg);


### PR DESCRIPTION
I hope I can help to refine the code examples section UI in the index page every time when I browse perl6.org. So I create this PR finally : )

Before: 

<img width="650" alt="WX20190428-005314@2x" src="https://user-images.githubusercontent.com/1658618/56852722-3e4cd180-6951-11e9-9221-02b5c60ae63b.png">

After:

<img width="864" alt="WX20190428-005411@2x" src="https://user-images.githubusercontent.com/1658618/56852727-5a507300-6951-11e9-9671-6f6c190d1060.png">

<img width="851" alt="WX20190428-005427@2x" src="https://user-images.githubusercontent.com/1658618/56852742-705e3380-6951-11e9-86b5-a9f805b97f00.png">


And I also set the `<pre>` tag a solid height to prevent a flashing when a tab is clicked. It's more than the height of the highest `<pre>` section at present. I guess the height is ok for such code snippets.
 