### PR TITLE
Remove 6.d announcement from the start page

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -24,21 +24,6 @@
       </div>
     </div>
     <div class="col-sm-12">
-      <div class="panel" style="box-shadow: 1px 1px 3px rgba(0, 0, 0, .3)">
-        <div class="panel-primary">
-          <div class="panel-heading">
-              <h3 class="panel-title">6.d Language Specification Released</h3>
-          </div>
-          <div class="panel-body trim" style="background: #fafafa">
-            <p style="font-size: 81%">
-                This is the second major language release.
-                Read the <a href="http://blogs.perl.org/users/zoffix_znet/2018/11/announce-raku-perl-6-diwali-6d-language-specification-release.html"
-                   >release announcement</a></p>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="col-sm-12">
       <h1>The <b>Raku</b> Programming Language</h1>
 
       <a href='https://github.com/perl6/mu/raw/master/misc/camelia.txt'


### PR DESCRIPTION
It's not news anymore. So don't header-bannerize our visitors with it.