### PR TITLE
Remove mention of the Perl community

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -32,11 +32,9 @@
         class="img-responsive"
       ></a>
 
-      <p>Hi, my name is Camelia.  I'm the spokesbug for Raku.
-        Raku intends to carry forward the high ideals of
-        the <a href="https://www.perlfoundation.org">Perl community</a>.
+      <p>Hi, my name is Camelia.  I'm the spokesbug for the Raku Programming Language.
         Raku has been developed by a team of dedicated and
-        enthusiastic volunteers, and continues to be developed. You
+        enthusiastic open source volunteers, and continues to be developed. You
         can help too. The only requirement is that you know
         how to be nice to all kinds of people (and butterflies). Go to
         <a href="https://kiwiirc.com/client/irc.libera.chat/#raku"


### PR DESCRIPTION
It has been almost 2 years since the name change.  People are starting to be confused about the mention of Perl on the home page.  Removing it feels correct in the sense that Raku is becoming more and more a thing on its own.  Also add "Programming Language" and "open source" for better SEO