### PR TITLE
Fixing glot.io link

### DIFF
--- a/source/resources/index.html
+++ b/source/resources/index.html
@@ -118,7 +118,7 @@
               <ul class="shy-list">
                   <li><a href="https://exercism.io/tracks/raku">Raku track on exercism.io</a></li>
                   <li><a href="https://repl.it/languages/raku">Online Raku compiler (most up to date)</a></li>
-                  <li><a href="https://glot.io/new/perl6">Online Raku REPL (glot.io)</a></li>
+                  <li><a href="https://glot.io/new/raku">Online Raku REPL (glot.io)</a></li>
                   <li><a href="https://tio.run/#perl6">Online Raku REPL (tio.run)</a></li>
               </ul>
           </div>


### PR DESCRIPTION
Hi,
fortunately, glot.io knows about Raku, as "Raku" - unfortunately, the raku.org site doesn't know this... glot.io gave "the language perl6 is not supported" for the current link. Time to get on with the times and fix the link on raku.org as well. :)