### PR TITLE
Removing unused mailing lists, actualizing year

### DIFF
--- a/source/community/index.html
+++ b/source/community/index.html
@@ -16,7 +16,7 @@
 </header>
 
 <div class="row equal-panels">
-  <div class="col-sm-5">
+  <div class="col-sm-7">
     <div class="panel panel-default">
         <div class="panel-body">
           <h3 class="trim-top">Internet Relay Chat (IRC)</h3>
@@ -71,7 +71,7 @@
     </div>
   </div>
 
-  <div class="col-sm-7">
+  <div class="col-sm-5">
     <div class="panel panel-default">
       <div class="panel-body trim">
         <h3 class="trim-top">Mailing lists</h3>
@@ -80,7 +80,7 @@
             can't use IRC) we have several mailing lists.
         </p>
         <p>
-            As of 2014, the lists have very low traffic
+            As of 2022, the lists have very low traffic
             (because most activity is on <a href="/community/irc">#raku</a>), but every
             question sent to it usually gets answered swiftly by at
             least one person.
@@ -91,17 +91,6 @@
         </p>
 
         <dl id="mailing-lists" class="trim-bottom">
-            <dt>perl6-announce</dt>
-            <dd>
-                <p>Moderated lists for announcements and news. Fairly low traffic
-                (a few mails per month).</p>
-                <p><a
-                href="mailto:perl6-announce-subscribe@perl.org"
-                  class="btn btn-sm btn-primary">Subscribe</a>
-                <a href="http://nntp.perl.org/group/perl.perl6.announce/"
-                  class="btn btn-sm btn-success">Archive</a></p>
-            </dd>
-
             <dt>perl6-language</dt>
             <dd>
                 <p>Discussions on the Raku language</p>
@@ -130,17 +119,6 @@
                   class="btn btn-sm btn-primary">Subscribe</a>
                 <a href="http://nntp.perl.org/group/perl.perl6.users/"
                   class="btn btn-sm btn-success">Archive</a></p>
-            </dd>
-
-            <dt>perl6-workshops</dt>
-            <dd>
-                <p>Coordination of events related to Raku (often together with
-                other Perl or open source events).</p>
-                <p><a
-                    href="http://groups.google.com/group/perl6-workshops?hl=en"
-                    class="btn btn-sm btn-primary">list info; subscription
-                    </a>
-                </p>
             </dd>
         </dl>
       </div>


### PR DESCRIPTION
Hello,

I think the mailing lists are somewhat overrepresented - because they are mostly legacy, even their complete removal could be considered but now, I only went for what seemed safe:

- changing the mentioned year: it really gives an abandoned impression when the only explicitly mentioned point in time is from 8 years ago; if it still applies (I think it does), it should be the current year
- the perl6-announce mailing list seemed completely dead - last message from 2015 - so it's better to remove it in my opinion
- the perl6-workshops mailing list is either removed or not publicly available so I don't think raku.org is a good place for it
- to reflect both the changes in size and the importance, I swapped the width of the two columns: now, the mailing list column is the smaller one

I think this is a minor step and not the only thing I would like to change but it was a good warmup for me as well and I think it is definitely a step forward. :)