### PR TITLE
Fixing broken/outdated links on the Whatever site.

### DIFF
--- a/source/whatever/index.html
+++ b/source/whatever/index.html
@@ -10,7 +10,7 @@
     <p>
         Everything that can't be categorized otherwise fits into the
         "Whatever" slot, or as the Raku hacker would write it,
-        <a href="https://docs.perl6.org/type/Whatever"><code>*</code></a>.
+        <a href="https://docs.raku.org/type/Whatever"><code>*</code></a>.
     </p>
 </header>
 
@@ -23,7 +23,7 @@
       <div class="panel-body">
         <h3>Module Management</h3>
         <ul class="shy-list">
-            <li><a href="https://modules.perl6.org/dist/zef">Zef</a> Raku
+            <li><a href="https://raku.land/github:ugexe/zef">Zef</a> Raku
             module manager</li>
         </ul>
         <h3>Editors and IDEs</h3>
@@ -68,9 +68,7 @@
       </div>
       <div class="panel-body">
         <ul class="shy-list">
-            <li><a href="https://rakudo.spreadshirt.com/">Spreadshirt</a> (<a
-                    href="https://rakudo.spreadshirt.net/de/DE/Shop/">Spreadshirt
-                    Germany</a>)</li>
+            <li><a href="https://www.spreadshirt.com/shop/rakudo/">Spreadshirt</a></li>
             <li><a href="https://cafepress.com/rakudo">Cafepress</a></li>
             <li><a href="https://www.zazzle.com/rakudo">Zazzle</a></li>
         </ul>


### PR DESCRIPTION
Hello,

I am still going for safety  with this PR - fixed the link of Zef and Spreadshirt (I could see one Raku-related product in the search so I changed to the link of the search), also changed a link that contained perl6.org, I suppose we aren't going back to those domains anymore so let's make it more future-proof. :)

PS: I'm still thinking about taking some changes over from raku-lang.ir but that's generally more tough. The footer shouldn't get huge, also, it might require some reconsideration of categories (e.g I think Rakubrew deserves the place in Download indeed but I don't know how much it belongs there logically).