### PR TITLE
Replaced url of article on non-existent https://perl6.party …

### DIFF
--- a/source/community/index.html
+++ b/source/community/index.html
@@ -158,7 +158,7 @@
       <p>
         Help increase test coverage of the official Raku test suite called <a href="https://github.com/Raku/roast">roast</a>.
         This is the high bar that all Raku implementations must meet. There's a lot of ground to cover, so get up to speed with the
-        <a href="https://docs.raku.org/language/testing">Test module</a>, if you don't already know it, <a href="https://perl6.party/post/A-Date-With-The-Bug-Queue-or-Let-Me-Help-You-Help-Me-Help-You">and join us!</a>
+        <a href="https://docs.raku.org/language/testing">Test module</a>, if you don't already know it, <a href="https://blogs.perl.org/users/zoffix_znet/2016/07/a-date-with-the-bug-queue-or-let-me-help-you-help-me-help-you.html">and join us!</a>
       </p>
       <h4>Contribute to the Ecosystem</h4>
       <p>
@@ -175,7 +175,7 @@
         NQP is a subset of Raku that is much smaller and simpler than Raku. Rakudo targets
         NQP. Then NQP targets various backend VMs like MoarVM, Javascript, and Java.
       </p><p>
-        So <a href="https://perl6.party/post/A-Date-With-The-Bug-Queue-or-Let-Me-Help-You-Help-Me-Help-You">you can get started right away</a> by writing Raku, and if/when you need to access
+        So <a href="https://blogs.perl.org/users/zoffix_znet/2016/07/a-date-with-the-bug-queue-or-let-me-help-you-help-me-help-you.html">you can get started right away</a> by writing Raku, and if/when you need to access
         some very low-level functionality you can learn NQP. You can get up to speed fairly
         fast with this <a href="https://github.com/edumentab/rakudo-and-nqp-internals-course">NQP learning course</a>.
         So feel free to jump right in!


### PR DESCRIPTION
… with same article on Zoffix Znet blog.

Seemed better to link to a live version:

https://blogs.perl.org/users/zoffix_znet/2016/07/a-date-with-the-bug-queue-or-let-me-help-you-help-me-help-you.html

rather than the archive:

https://web.archive.org/web/20200928093308/https://perl6.party/post/A-Date-With-The-Bug-Queue-or-Let-Me-Help-You-Help-Me-Help-You