### PR TITLE
Remove the links to the test queue blog posts

### DIFF
--- a/source/community/index.html
+++ b/source/community/index.html
@@ -159,7 +159,7 @@
       <p>
         Help increase test coverage of the official Raku test suite called <a href="https://github.com/Raku/roast">roast</a>.
         This is the high bar that all Raku implementations must meet. There's a lot of ground to cover, so get up to speed with the
-        <a href="https://docs.raku.org/language/testing">Test module</a>, if you don't already know it, <a href="https://perl6.party/post/A-Date-With-The-Bug-Queue-or-Let-Me-Help-You-Help-Me-Help-You">and join us!</a>
+        <a href="https://docs.raku.org/language/testing">Test module</a>, if you don't already know it, and join us!
       </p>
       <h4>Contribute to the Ecosystem</h4>
       <p>
@@ -176,7 +176,7 @@
         NQP is a subset of Raku that is much smaller and simpler than Raku. Rakudo targets
         NQP. Then NQP targets various backend VMs like MoarVM, Javascript, and Java.
       </p><p>
-        So <a href="https://perl6.party/post/A-Date-With-The-Bug-Queue-or-Let-Me-Help-You-Help-Me-Help-You">you can get started right away</a> by writing Raku, and if/when you need to access
+        So you can get started right away by writing Raku, and if/when you need to access
         some very low-level functionality you can learn NQP. You can get up to speed fairly
         fast with this <a href="https://github.com/edumentab/rakudo-and-nqp-internals-course">NQP learning course</a>.
         So feel free to jump right in!


### PR DESCRIPTION
The current link doesn't exist and the article aged so badly (being mostly about RT usage) that it would be hard to even fix. It's not worth linking from CCR.