### PR TITLE
Remedying perl6.party links

### DIFF
--- a/source/community/index.html
+++ b/source/community/index.html
@@ -159,7 +159,7 @@
       <p>
         Help increase test coverage of the official Raku test suite called <a href="https://github.com/Raku/roast">roast</a>.
         This is the high bar that all Raku implementations must meet. There's a lot of ground to cover, so get up to speed with the
-        <a href="https://docs.raku.org/language/testing">Test module</a>, if you don't already know it, <a href="https://perl6.party/post/A-Date-With-The-Bug-Queue-or-Let-Me-Help-You-Help-Me-Help-You">and join us!</a>
+        <a href="https://docs.raku.org/language/testing">Test module</a>, if you don't already know it, and join us!
       </p>
       <h4>Contribute to the Ecosystem</h4>
       <p>
@@ -176,7 +176,7 @@
         NQP is a subset of Raku that is much smaller and simpler than Raku. Rakudo targets
         NQP. Then NQP targets various backend VMs like MoarVM, Javascript, and Java.
       </p><p>
-        So <a href="https://perl6.party/post/A-Date-With-The-Bug-Queue-or-Let-Me-Help-You-Help-Me-Help-You">you can get started right away</a> by writing Raku, and if/when you need to access
+        So you can get started right away by writing Raku, and if/when you need to access
         some very low-level functionality you can learn NQP. You can get up to speed fairly
         fast with this <a href="https://github.com/edumentab/rakudo-and-nqp-internals-course">NQP learning course</a>.
         So feel free to jump right in!

--- a/source/fun/index.html
+++ b/source/fun/index.html
@@ -32,7 +32,7 @@
         href="http://pugs.blogs.com/audrey/2009/08/my-hobby-troll-hugging.html">My
         hobby: Troll hugging</li>
     <li class="list-group-item"><a
-        href="https://perl6.party/post/On-Troll-Hugging-Hole-Digging-and-Improving-Open-Source-Communities"
+        href="https://github.com/Raku/CCR/blob/main/Remaster/Zoffix%20Znet/On-Troll-Hugging-Hole-Digging-and-Improving-Open-Source-Communities.md"
             >On Troll Hugging, Hole Digging, and Improving Open Source Communities</li>
     <li class="list-group-item"><a
         href="https://effectiviology.com/principle-of-charity/">The Principle of Charity</a>: on the


### PR DESCRIPTION
There were 3 links under the sources that contained "perl6.party". I changed one of them into a github link in the CCR project, for the lack of a better option, and I eliminated the other two because I found them too outdated. The original article can be found [on CCR for that one as well](https://github.com/Raku/CCR/blob/main/Remaster/Zoffix%20Znet/A-Date-With-The-Bug-Queue-or-Let-Me-Help-You-Help-Me-Help-You.md).