### PR TITLE
Add Dockerfile to serve static files with Caddy

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,5 @@
+http://localhost:5500 {
+    root * /usr/share/caddy
+    file_server
+}
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM docker.io/perl:5.38.0 as builder
+
+WORKDIR /usr/src/app
+
+RUN cpan App::Mowyw
+RUN cpan Plack
+RUN cpan Mojo::UserAgent
+
+COPY . .
+RUN perl fetch-recent-blog-posts.pl
+RUN mowyw
+
+FROM docker.io/caddy:latest
+# Processed static files are written to ./online
+COPY --from=builder /usr/src/app/online /usr/share/caddy
+COPY Caddyfile /etc/caddy/Caddyfile
+


### PR DESCRIPTION
We add a basic Caddyfile that compiles static assets to ./online and then serves these from the web root /usr/share/caddy inside the container.

404 handlers are TODO